### PR TITLE
Use Ansible service module instead of start/stop

### DIFF
--- a/couchdb/handlers/main.yml
+++ b/couchdb/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: restart couchdb
   become: yes
-  command: restart couchdb
+  service:
+    name: couchdb
+    state: restarted

--- a/couchdb/tasks/install.yml
+++ b/couchdb/tasks/install.yml
@@ -12,7 +12,9 @@
 
 - name: stop couchdb
   become: yes
-  command: stop couchdb
+  service:
+    name: couchdb
+    state: stopped
   when: couchdb_install.changed
 
 - name: change owner of couchdb executable
@@ -39,7 +41,9 @@
 
 - name: start couchdb
   become: yes
-  command: start couchdb
+  service:
+    name: couchdb
+    state: started
   when: couchdb_install.changed
 
 - name: setup admins


### PR DESCRIPTION
When starting or stopping CouchDB, ansible thows this message:

> fatal: [database-0]: FAILED! => {"changed": false, "cmd": "stop couchdb", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}

Using Ansible's [service module](http://docs.ansible.com/ansible/service_module.html) this issue is fixed and everything works as expected.